### PR TITLE
Version 1.4.5 - Critical multi-meter fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,23 +229,20 @@ Der Adapter setzt Zähler automatisch zurück:
 
 ## Changelog
 
-### **WORK IN PROGRESS**
+### 1.4.5 (2026-01-20)
 
-### 1.4.4 (2026-01-18)
-
-- **FIX:** 🐛 **lastYearStart Recalculation Bug** - Fixed incorrect month count in paidTotal:
-    - `lastYearStart` is now always recalculated from `contractStart` on adapter initialization
-    - Fixes cases where `lastYearStart` was set incorrectly (e.g., 01.01.2026 instead of contract date)
-    - Ensures `monthsSinceYearStart` is always calculated correctly based on actual contract date
-    - Resolves issue where `paidTotal` showed only 1 month payment instead of correct accumulated amount
-
-### 1.4.3 (2026-01-18)
-
-- **FIX:** 🐛 **Critical paidTotal Calculation Bug** - Fixed incorrect paidTotal after sensor updates:
-    - `paidTotal` was stored as string instead of timestamp, causing parsing errors in `updateCosts()`
-    - Changed `lastYearStart`, `lastMonthStart`, `lastDayStart` to store timestamps (number) instead of formatted strings
-    - Now correctly calculates `paidTotal = monthlyPayment × monthsSinceYearStart` for both adapter restart and sensor updates
-    - Backward compatible: existing string values auto-convert to timestamps on next update
+- **FIX:** 🐛 **Critical Multi-Meter Cost Calculation Bugs** - Comprehensive fixes for multi-meter functionality:
+    - **Main Meter Sync Issue**: Removed duplicate initialization that prevented `lastSync` updates on main meter
+    - **basicCharge Accumulation**: Now correctly calculates `basicCharge = grundgebuehr × months` (was showing only 1 month)
+    - **paidTotal Accumulation**: Now correctly calculates `paidTotal = abschlag × months` (was showing only 1 month)
+    - **annualFee as Fixed Value**: Jahresgebühr is now used as fixed yearly value (e.g., 60€ stays 60€)
+      - Previously incorrectly treated as monthly fee and multiplied by months
+      - User-entered value in config (e.g., 60€) is now used directly as intended
+    - **Balance Formula Corrected**: Fixed reversed formula `balance = totalYearly - paidTotal`
+      - Positive balance = Nachzahlung (you owe money)
+      - Negative balance = Guthaben (you get money back)
+- **IMPROVED:** 📦 **Dev-Dependencies**: Updated from tilde (~) to caret (^) versioning for better security updates
+- **CLEANUP:** 🧹 **Repository Compliance**: Removed unpublished versions from changelog (resolves ioBroker Bot Issue #1)
 
 ### 1.4.2 (2026-01-18)
 
@@ -268,44 +265,6 @@ Der Adapter setzt Zähler automatisch zurück:
     - `safeSetObjectNotExists()` catches and logs state creation failures
     - Prevents silent failures in StateManager
 - **IMPROVED:** 🧪 **Code Quality** - All tests passing (31 unit + 57 package tests)
-
-### 1.4.1 (2026-01-18)
-
-- **FIX:** 🐛 **Multi-Meter Critical Bugs** - Comprehensive fixes for multi-meter functionality:
-    - Fixed `updateCosts()` to correctly delegate to multiMeterManager for all meters
-    - Fixed `closeBillingPeriod()` to archive totals instead of only main meter values
-    - Fixed `checkMonthlyReport()` to display totals in reports for multi-meter setups
-    - Fixed state type mismatch: `lastDayStart`, `lastMonthStart`, `lastYearStart` now use number (timestamp) instead of string
-- **NEW:** 🎯 **Per-Meter Billing Closure** - Each meter can now be closed individually with its own `billing.closePeriod` button
-    - Main meter: `gas.billing.closePeriod`
-    - Additional meters: `gas.erdgeschoss.billing.closePeriod`, `gas.keller.billing.closePeriod`, etc.
-    - Each meter uses its own contract date for yearly resets
-- **NEW:** 📅 **Individual Contract Anniversary Resets** - Each meter resets on its own contract date
-    - Primary: Manual `closePeriod` triggers yearly reset immediately
-    - Fallback: Automatic reset on contract anniversary if user forgets to close period
-    - Contract date is preserved when closing period early (no drift)
-- **IMPROVED:** 💰 **Billing Period Closure** - No longer resets `basicCharge` and `annualFee` to zero
-    - These values now persist from config (user must update config if tariff changes)
-    - Helpful reminder message added after closing period
-- **FIX:** 🤖 **ioBroker Bot Compliance** - All bot checker issues resolved:
-    - Removed non-existent version 1.3.4 from news
-    - Added complete translations for all news entries (9 languages)
-    - Removed `.npmignore` file (using `files` field in package.json)
-    - DevDependencies already use `~` syntax (compliant)
-
-### 1.4.0 (2026-01-17)
-
-- **NEW:** 🎉 **Multi-Meter Support** - Verwende mehrere Zähler pro Typ (z.B. Gas Hauptzähler + Werkstatt-Zähler)
-    - Beliebig viele zusätzliche Zähler mit eigenen Namen konfigurierbar
-    - Separate Kostenberechnung und Statistiken pro Zähler
-    - Automatische Totals-Berechnung über alle Zähler
-- **NEW:** ✨ **Komma-Dezimaltrenner Support** - Admin UI akzeptiert jetzt sowohl Komma als auch Punkt (z.B. `12,50` oder `12.50`)
-- **NEW:** 📊 **Pro-Meter Billing** - Jeder Zähler hat eigene `billing.daysRemaining` und `billing.periodEnd` Werte
-- **NEW:** 🔧 **Config-Parser** - Automatische Konvertierung von String→Number mit Komma-Support
-- **FIX:** 💰 **Balance-Berechnung korrigiert** - Nutzt jetzt begonnene Monate statt volle Monate (17 Tage = 1 Monat gezahlt)
-- **FIX:** 🐛 **String-Type Fehler** behoben - Config-Werte werden korrekt als Numbers verarbeitet
-- **IMPROVED:** 🔍 **Debug-Logging** - Hilfreiche Debug-Logs für Troubleshooting (nur in Debug-Modus sichtbar)
-- **CLEANUP:** 🧹 Repository aufgeräumt - Alte Backup-Dateien und temporäre Scripts entfernt
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Für jede aktivierte Verbrauchsart (Gas/Wasser/Strom/PV) werden folgende Ordner 
 | `daily`       | Kosten **heute**                                              | daily × Arbeitspreis                       | 2,27 €                         |
 | `monthly`     | Kosten **diesen Monat**                                       | monthly × Arbeitspreis                     | 21,61 €                        |
 | `yearly`      | **Verbrauchskosten** seit Vertragsbeginn                      | yearly × Arbeitspreis                      | 137,61 €                       |
-| `totalYearly` | **Gesamtkosten Jahr** (Verbrauch + alle Fixkosten)            | yearly-cost + basicCharge + annualFee      | 162,64 €                       |
-| `basicCharge` | **Grundgebühr akkumuliert** (inkl. Jahresgebühr anteilig)     | (Grundgebühr + (Jahresgebühr/12)) × Monate | 19,20 €                        |
-| `annualFee`   | **Jahresgebühr akkumuliert**                                  | (Jahresgebühr / 12) × Monate               | 4,17 €                         |
+| `totalYearly` | **Gesamtkosten Jahr** (Verbrauch + alle Fixkosten)            | yearly-cost + basicCharge + annualFee      | 212,64 €                       |
+| `basicCharge` | **Grundgebühr akkumuliert**                                   | Grundgebühr × Monate                       | 15,03 €                        |
+| `annualFee`   | **Jahresgebühr** (fester Wert pro Jahr)                       | Jahresgebühr (aus Config)                  | 60,00 €                        |
 | `paidTotal`   | **Bezahlt** via Abschlag                                      | Abschlag × Monate                          | 150,00 €                       |
-| `balance`     | **🎯 WICHTIGSTER Wert!**<br>Nachzahlung (+) oder Guthaben (-) | totalYearly - paidTotal                    | **+12,64 €**<br>→ Nachzahlung! |
+| `balance`     | **🎯 WICHTIGSTER Wert!**<br>Nachzahlung (+) oder Guthaben (-) | totalYearly - paidTotal                    | **+62,64 €**<br>→ Nachzahlung! |
 
 #### 🔍 **balance** genauer erklärt:
 
@@ -112,13 +112,14 @@ Für jede aktivierte Verbrauchsart (Gas/Wasser/Strom/PV) werden folgende Ordner 
 
 ```
 Verbrauchskosten:  137,61 € (yearly)
-Grundgebühr:      + 15,03 € (basicCharge)
+Grundgebühr:      + 15,03 € (basicCharge - 1 Monat × 15,03€)
+Jahresgebühr:     + 60,00 € (annualFee - fester Wert)
 ────────────────────────────
-Gesamtkosten:      152,64 €
+Gesamtkosten:      212,64 € (totalYearly)
 
-Bezahlt (Abschlag): 150,00 € (paidTotal)
+Bezahlt (Abschlag): 150,00 € (paidTotal - 1 Monat × 150€)
 ────────────────────────────
-Balance:           +2,64 € → Nachzahlung
+Balance:           +62,64 € → Nachzahlung
 ```
 
 ---

--- a/io-package.json
+++ b/io-package.json
@@ -1,33 +1,20 @@
 {
     "common": {
         "name": "utility-monitor",
-        "version": "1.4.4",
+        "version": "1.4.5",
         "news": {
-            "1.4.4": {
-                "en": "Fix: lastYearStart now always recalculated from contract date on adapter start - fixes wrong month count in paidTotal",
-                "de": "Fix: lastYearStart wird jetzt immer aus Vertragsbeginn neu berechnet - behebt falsche Monatszahl in paidTotal",
-                "ru": "Исправление: lastYearStart теперь всегда пересчитывается из даты договора при запуске - исправляет неправильный подсчет месяцев в paidTotal",
-                "pt": "Correção: lastYearStart agora sempre recalculado da data do contrato na inicialização - corrige contagem incorreta de meses em paidTotal",
-                "nl": "Fix: lastYearStart nu altijd herberekend vanaf contractdatum bij start - lost onjuiste maandtelling in paidTotal op",
-                "fr": "Correction: lastYearStart maintenant toujours recalculé à partir de la date du contrat au démarrage - corrige le comptage incorrect des mois dans paidTotal",
-                "it": "Correzione: lastYearStart ora sempre ricalcolato dalla data contratto all'avvio - corregge conteggio errato mesi in paidTotal",
-                "es": "Corrección: lastYearStart ahora siempre recalculado desde fecha contrato al iniciar - corrige recuento incorrecto meses en paidTotal",
-                "pl": "Naprawa: lastYearStart teraz zawsze przeliczany z daty umowy przy starcie - naprawia błędne liczenie miesięcy w paidTotal",
-                "uk": "Виправлення: lastYearStart тепер завжди перераховується з дати договору при запуску - виправляє неправильний підрахунок місяців у paidTotal",
-                "zh-cn": "修复：lastYearStart现在在启动时始终从合同日期重新计算 - 修复paidTotal中的错误月数计数"
-            },
-            "1.4.3": {
-                "en": "Fix: Critical paidTotal calculation bug - now correctly calculates (monthly payment × months) after sensor updates",
-                "de": "Fix: Kritischer paidTotal-Berechnungsfehler - berechnet jetzt korrekt (monatlicher Abschlag × Monate) nach Sensor-Updates",
-                "ru": "Исправление: Критическая ошибка расчета paidTotal - теперь правильно вычисляет (ежемесячный платеж × месяцы) после обновлений датчика",
-                "pt": "Correção: Bug crítico de cálculo paidTotal - agora calcula corretamente (pagamento mensal × meses) após atualizações do sensor",
-                "nl": "Fix: Kritieke paidTotal-berekeningsfout - berekent nu correct (maandelijkse betaling × maanden) na sensor-updates",
-                "fr": "Correction: Bug critique de calcul paidTotal - calcule maintenant correctement (paiement mensuel × mois) après les mises à jour du capteur",
-                "it": "Correzione: Bug critico calcolo paidTotal - ora calcola correttamente (pagamento mensile × mesi) dopo aggiornamenti sensore",
-                "es": "Corrección: Bug crítico de cálculo paidTotal - ahora calcula correctamente (pago mensual × meses) después de actualizaciones del sensor",
-                "pl": "Naprawa: Krytyczny błąd obliczania paidTotal - teraz poprawnie oblicza (płatność miesięczna × miesiące) po aktualizacjach czujnika",
-                "uk": "Виправлення: Критична помилка розрахунку paidTotal - тепер правильно обчислює (щомісячний платіж × місяці) після оновлень датчика",
-                "zh-cn": "修复：关键的paidTotal计算错误 - 现在在传感器更新后正确计算（月付款×月数）"
+            "1.4.5": {
+                "en": "Fix: Critical multi-meter cost calculation bugs (main meter sync, basicCharge/paidTotal accumulation, annualFee as fixed yearly value). Fix: Balance formula corrected. Fix: Removed duplicate initialization causing sync issues.",
+                "de": "Fix: Kritische Multi-Meter Kostenberechnungsfehler (Hauptzähler-Sync, basicCharge/paidTotal Akkumulation, Jahresgebühr als fester Jahreswert). Fix: Balance-Formel korrigiert. Fix: Doppelte Initialisierung entfernt.",
+                "ru": "Исправление: Критические ошибки расчета затрат multi-meter (синхронизация главного счетчика, накопление basicCharge/paidTotal, annualFee как фиксированное годовое значение). Исправление: Формула баланса исправлена. Исправление: Удалена дублирующая инициализация.",
+                "pt": "Correção: Bugs críticos de cálculo de custos multi-medidor (sincronização medidor principal, acumulação basicCharge/paidTotal, annualFee como valor anual fixo). Correção: Fórmula de saldo corrigida. Correção: Inicialização duplicada removida.",
+                "nl": "Fix: Kritieke multi-meter kostenberekeningsfouten (hoofdmeter sync, basicCharge/paidTotal accumulatie, annualFee als vaste jaarwaarde). Fix: Balans formule gecorrigeerd. Fix: Dubbele initialisatie verwijderd.",
+                "fr": "Correction: Bugs critiques calcul coûts multi-compteurs (sync compteur principal, accumulation basicCharge/paidTotal, annualFee comme valeur annuelle fixe). Correction: Formule de solde corrigée. Correction: Initialisation en double supprimée.",
+                "it": "Correzione: Bug critici calcolo costi multi-contatore (sync contatore principale, accumulazione basicCharge/paidTotal, annualFee come valore annuale fisso). Correzione: Formula bilancio corretta. Correzione: Inizializzazione duplicata rimossa.",
+                "es": "Corrección: Bugs críticos cálculo costos multi-medidor (sincronización medidor principal, acumulación basicCharge/paidTotal, annualFee como valor anual fijo). Corrección: Fórmula balance corregida. Corrección: Inicialización duplicada eliminada.",
+                "pl": "Naprawa: Krytyczne błędy obliczania kosztów multi-meter (synchronizacja głównego licznika, akumulacja basicCharge/paidTotal, annualFee jako stała wartość roczna). Naprawa: Formuła salda poprawiona. Naprawa: Usunięto podwójną inicjalizację.",
+                "uk": "Виправлення: Критичні помилки розрахунку витрат multi-meter (синхронізація головного лічильника, накопичення basicCharge/paidTotal, annualFee як фіксоване річне значення). Виправлення: Формула балансу виправлена. Виправлення: Видалено подвійну ініціалізацію.",
+                "zh-cn": "修复：关键多表成本计算错误（主表同步、basicCharge/paidTotal累积、annualFee作为固定年值）。修复：余额公式已更正。修复：删除重复初始化。"
             },
             "1.4.2": {
                 "en": "Fix: Critical multi-meter balance bug (hardcoded 12 months). Fix: TypeScript errors resolved. New: Enhanced input validation. New: Extended constants. New: Error handling wrapper.",
@@ -41,32 +28,6 @@
                 "pl": "Naprawa: Krytyczny błąd salda multi-meter (zakodowane 12 miesięcy). Naprawa: Naprawione błędy TypeScript. Nowe: Ulepszona walidacja danych. Nowe: Rozszerzone stałe. Nowe: Wrapper obsługi błędów.",
                 "uk": "Виправлення: Критична помилка балансу multi-meter (жорстко задані 12 місяців). Виправлення: Усунено помилки TypeScript. Нове: Покращена перевірка даних. Нове: Розширені константи. Нове: Обробник помилок.",
                 "zh-cn": "修复：关键多表余额错误（硬编码12个月）。修复：解决TypeScript错误。新增：增强输入验证。新增：扩展常量。新增：错误处理包装器。"
-            },
-            "1.4.1": {
-                "en": "Fix: Multi-meter bugs (cost calculation, billing period closure, monthly reports, yearly resets). Fix: Per-meter billing closure support. Fix: State type corrections (lastDayStart). Fix: ioBroker Bot compliance.",
-                "de": "Fix: Multi-Meter-Fehler (Kostenberechnung, Periodenabschluss, Monatsberichte, Jahres-Resets). Fix: Zähler-individuelle Periodenabschlüsse. Fix: State-Typ-Korrekturen (lastDayStart). Fix: ioBroker Bot-Compliance.",
-                "ru": "Исправление: Ошибки нескольких счетчиков (расчет затрат, закрытие периода, ежемесячные отчеты, годовые сбросы). Исправление: Поддержка закрытия периода для каждого счетчика. Исправление: Исправления типов состояний. Исправление: Соответствие ioBroker Bot.",
-                "pt": "Correção: Bugs multi-medidor (cálculo custos, fechamento período, relatórios mensais, resets anuais). Correção: Suporte fechamento período por medidor. Correção: Correções tipo estado. Correção: Conformidade Bot ioBroker.",
-                "nl": "Fix: Multi-meter bugs (kostenberekening, periode afsluiting, maandraporten, jaarlijkse resets). Fix: Per-meter periode afsluiting. Fix: State type correcties. Fix: ioBroker Bot compliance.",
-                "fr": "Correction: Bugs multi-compteurs (calcul coûts, clôture période, rapports mensuels, réinitialisations annuelles). Correction: Support clôture période par compteur. Correction: Corrections type d'état. Correction: Conformité Bot ioBroker.",
-                "it": "Correzione: Bug multi-contatore (calcolo costi, chiusura periodo, report mensili, reset annuali). Correzione: Supporto chiusura periodo per contatore. Correzione: Correzioni tipo stato. Correzione: Conformità Bot ioBroker.",
-                "es": "Corrección: Bugs multi-medidor (cálculo costos, cierre período, informes mensuales, reinicios anuales). Corrección: Soporte cierre período por medidor. Corrección: Correcciones tipo estado. Corrección: Cumplimiento Bot ioBroker.",
-                "pl": "Naprawa: Błędy wielu liczników (obliczanie kosztów, zamknięcie okresu, raporty miesięczne, resety roczne). Naprawa: Wsparcie zamknięcia okresu dla licznika. Naprawa: Poprawki typu stanu. Naprawa: Zgodność z Bot ioBroker.",
-                "uk": "Виправлення: Помилки кількох лічильників (розрахунок витрат, закриття періоду, місячні звіти, річні скидання). Виправлення: Підтримка закриття періоду для лічильника. Виправлення: Виправлення типу стану. Виправлення: Відповідність ioBroker Bot.",
-                "zh-cn": "修复：多表错误（成本计算、期间关闭、月度报告、年度重置）。修复：每表期间关闭支持。修复：状态类型更正。修复：ioBroker Bot合规性。"
-            },
-            "1.4.0": {
-                "en": "New: Multi-Meter Support! Add unlimited custom-named meters per utility type (gas, water, electricity). Automatic totals calculation. Fully backward compatible.",
-                "de": "Neu: Multi-Meter-Unterstützung! Unbegrenzt viele Zähler pro Medium (Gas, Wasser, Strom) mit benutzerdefinierten Namen. Automatische Gesamt-Summen. Vollständig rückwärtskompatibel.",
-                "ru": "Новое: Поддержка нескольких счетчиков! Добавьте неограниченное количество пользовательских счетчиков для каждого типа коммунальных услуг (газ, вода, электричество). Автоматический расчет итогов. Полная обратная совместимость.",
-                "pt": "Novo: Suporte Multi-Medidor! Adicione medidores personalizados ilimitados por tipo de utilidade (gás, água, eletricidade). Cálculo automático de totais. Totalmente compatível com versões anteriores.",
-                "nl": "Nieuw: Multi-Meter Ondersteuning! Voeg onbeperkt aangepaste meters toe per type (gas, water, elektriciteit). Automatische totaalberekening. Volledig achterwaarts compatibel.",
-                "fr": "Nouveau: Support Multi-Compteur! Ajoutez des compteurs personnalisés illimités par type de service (gaz, eau, électricité). Calcul automatique des totaux. Entièrement rétrocompatible.",
-                "it": "Nuovo: Supporto Multi-Contatore! Aggiungi contatori personalizzati illimitati per tipo di servizio (gas, acqua, elettricità). Calcolo automatico dei totali. Completamente retrocompatibile.",
-                "es": "Nuevo: Soporte Multi-Medidor! Agregue medidores personalizados ilimitados por tipo de servicio (gas, agua, electricidad). Cálculo automático de totales. Totalmente compatible con versiones anteriores.",
-                "pl": "Nowe: Obsługa Wielu Liczników! Dodaj nieograniczoną liczbę niestandardowych liczników dla każdego typu mediów (gaz, woda, prąd). Automatyczne obliczanie sum. Pełna kompatybilność wsteczna.",
-                "uk": "Нове: Підтримка кількох лічильників! Додайте необмежену кількість власних лічильників для кожного типу комунальних послуг (газ, вода, електрика). Автоматичний розрахунок підсумків. Повна зворотна сумісність.",
-                "zh-cn": "新增：多表支持！为每种公用事业类型（燃气、水、电）添加无限的自定义计量表。自动总计计算。完全向后兼容。"
             }
         },
         "titleLang": {

--- a/lib/billingManager.js
+++ b/lib/billingManager.js
@@ -155,10 +155,14 @@ class BillingManager {
             monthsSinceContract = Math.max(1, yDiff * 12 + mDiff + 1);
         }
 
+        // Calculate accumulated basic charge (monthly fee × months)
         const basicChargeAccumulated = basicChargeMonthly * monthsSinceContract;
-        const annualFeeAccumulated = (annualFeePerYear / 12) * monthsSinceContract;
-        const totalFixCostsAccumulated = basicChargeAccumulated + annualFeeAccumulated;
-        const totalYearlyCost = yearlyConsumptionCost + totalFixCostsAccumulated;
+
+        // Jahresgebühr ist ein FIXER Wert pro Jahr (z.B. 60€)
+        // NICHT pro-rata nach Monaten/Tagen berechnen!
+        const annualFeeAccumulated = annualFeePerYear;
+
+        const totalYearlyCost = yearlyConsumptionCost + basicChargeAccumulated + annualFeeAccumulated;
 
         // Update states
         await this.adapter.setStateAsync(
@@ -186,9 +190,11 @@ class BillingManager {
             calculator.roundToDecimals(annualFeeAccumulated, 2),
             true,
         );
+        // basicCharge enthält NUR die monatliche Grundgebühr (akkumuliert)
+        // Jahresgebühr ist separat in annualFee
         await this.adapter.setStateAsync(
             `${type}.costs.basicCharge`,
-            calculator.roundToDecimals(totalFixCostsAccumulated, 2),
+            calculator.roundToDecimals(basicChargeAccumulated, 2),
             true,
         );
 

--- a/lib/multiMeterManager.js
+++ b/lib/multiMeterManager.js
@@ -601,16 +601,8 @@ class MultiMeterManager {
             `[${basePath}] Balance calculation: grundgebuehr=${config.grundgebuehr}, jahresgebuehr=${config.jahresgebuehr}, abschlag=${config.abschlag}, months=${monthsSinceYearStart}, basicCharge=${basicChargeAccumulated.toFixed(2)}, annualFee=${annualFeeAccumulated.toFixed(2)}, paidTotal=${paidTotal.toFixed(2)}, totalYearly=${totalYearlyCost.toFixed(2)}, balance=${balance.toFixed(2)}`,
         );
 
-        await this.adapter.setStateAsync(
-            `${basePath}.costs.paidTotal`,
-            calculator.roundToDecimals(paidTotal, 2),
-            true,
-        );
-        await this.adapter.setStateAsync(
-            `${basePath}.costs.balance`,
-            calculator.roundToDecimals(balance, 2),
-            true,
-        );
+        await this.adapter.setStateAsync(`${basePath}.costs.paidTotal`, calculator.roundToDecimals(paidTotal, 2), true);
+        await this.adapter.setStateAsync(`${basePath}.costs.balance`, calculator.roundToDecimals(balance, 2), true);
     }
 
     /**

--- a/lib/multiMeterManager.js
+++ b/lib/multiMeterManager.js
@@ -549,24 +549,35 @@ class MultiMeterManager {
         await this.adapter.setStateAsync(`${basePath}.costs.monthly`, calculator.roundToDecimals(monthlyCost, 2), true);
         await this.adapter.setStateAsync(`${basePath}.costs.yearly`, calculator.roundToDecimals(yearlyCost, 2), true);
 
-        await this.adapter.setStateAsync(`${basePath}.costs.basicCharge`, Number(config.grundgebuehr) || 0, true);
-
-        // Calculate annual fee (prorated)
+        // Calculate accumulated costs based on contract start
         const yearStartState = await this.adapter.getStateAsync(`${basePath}.statistics.lastYearStart`);
-        let annualFeeAccumulated = 0;
+        let monthsSinceYearStart = 1;
+        let basicChargeAccumulated = 0;
 
         if (yearStartState && yearStartState.val) {
             // yearStartState.val is a timestamp (number)
             const yearStartDate = new Date(yearStartState.val);
             if (!isNaN(yearStartDate.getTime())) {
                 const now = new Date();
-                const yearStartTime = yearStartDate.getTime();
-                const nowTime = now.getTime();
-                const daysSinceYearStart = Math.floor((nowTime - yearStartTime) / (1000 * 60 * 60 * 24));
-                const daysInYear = calculator.isLeapYear(now.getFullYear()) ? 366 : 365;
-                annualFeeAccumulated = ((config.jahresgebuehr || 0) / daysInYear) * daysSinceYearStart;
+
+                // Calculate months since contract start (started months, including current)
+                monthsSinceYearStart = calculator.getMonthsDifference(yearStartDate, now) + 1;
+
+                // Calculate accumulated basic charge (monthly fee × months)
+                basicChargeAccumulated = (config.grundgebuehr || 0) * monthsSinceYearStart;
             }
         }
+
+        // Jahresgebühr ist ein FIXER Wert pro Jahr (z.B. 60€)
+        // NICHT pro-rata nach Monaten/Tagen berechnen!
+        const annualFeeAccumulated = config.jahresgebuehr || 0;
+
+        // Update basicCharge with accumulated value (not just monthly!)
+        await this.adapter.setStateAsync(
+            `${basePath}.costs.basicCharge`,
+            calculator.roundToDecimals(basicChargeAccumulated, 2),
+            true,
+        );
 
         await this.adapter.setStateAsync(
             `${basePath}.costs.annualFee`,
@@ -574,61 +585,32 @@ class MultiMeterManager {
             true,
         );
 
-        // Calculate balance and total yearly costs
-        if (yearStartState && yearStartState.val) {
-            // yearStartState.val is a timestamp (number)
-            const yearStartDate = new Date(yearStartState.val);
-            if (!isNaN(yearStartDate.getTime())) {
-                const now = new Date();
-                // Calculate paid total based on started months (not just completed months)
-                // If current month has started, count it as paid
-                const monthsSinceYearStart = calculator.getMonthsDifference(yearStartDate, now) + 1;
+        // Calculate total yearly costs and balance
+        const totalYearlyCost = yearlyCost + basicChargeAccumulated + annualFeeAccumulated;
 
-                // Calculate total yearly costs with correct months
-                const basicChargeAccumulated = (config.grundgebuehr || 0) * monthsSinceYearStart;
-                const totalYearlyCost = yearlyCost + basicChargeAccumulated + annualFeeAccumulated;
+        await this.adapter.setStateAsync(
+            `${basePath}.costs.totalYearly`,
+            calculator.roundToDecimals(totalYearlyCost, 2),
+            true,
+        );
 
-                await this.adapter.setStateAsync(
-                    `${basePath}.costs.totalYearly`,
-                    calculator.roundToDecimals(totalYearlyCost, 2),
-                    true,
-                );
+        const paidTotal = (config.abschlag || 0) * monthsSinceYearStart;
+        const balance = totalYearlyCost - paidTotal;
 
-                const paidTotal = (config.abschlag || 0) * monthsSinceYearStart;
-                const balance = paidTotal - totalYearlyCost;
+        this.adapter.log.debug(
+            `[${basePath}] Balance calculation: grundgebuehr=${config.grundgebuehr}, jahresgebuehr=${config.jahresgebuehr}, abschlag=${config.abschlag}, months=${monthsSinceYearStart}, basicCharge=${basicChargeAccumulated.toFixed(2)}, annualFee=${annualFeeAccumulated.toFixed(2)}, paidTotal=${paidTotal.toFixed(2)}, totalYearly=${totalYearlyCost.toFixed(2)}, balance=${balance.toFixed(2)}`,
+        );
 
-                this.adapter.log.debug(
-                    `[${basePath}] Balance calculation: abschlag=${config.abschlag}, months=${monthsSinceYearStart}, paidTotal=${paidTotal.toFixed(2)}, totalYearly=${totalYearlyCost.toFixed(2)}, balance=${balance.toFixed(2)}`,
-                );
-
-                await this.adapter.setStateAsync(
-                    `${basePath}.costs.paidTotal`,
-                    calculator.roundToDecimals(paidTotal, 2),
-                    true,
-                );
-                await this.adapter.setStateAsync(
-                    `${basePath}.costs.balance`,
-                    calculator.roundToDecimals(balance, 2),
-                    true,
-                );
-            } else {
-                // Fallback if yearStartDate parsing fails
-                const totalYearlyCost = yearlyCost + annualFeeAccumulated;
-                await this.adapter.setStateAsync(
-                    `${basePath}.costs.totalYearly`,
-                    calculator.roundToDecimals(totalYearlyCost, 2),
-                    true,
-                );
-            }
-        } else {
-            // Fallback if no yearStartState exists
-            const totalYearlyCost = yearlyCost + annualFeeAccumulated;
-            await this.adapter.setStateAsync(
-                `${basePath}.costs.totalYearly`,
-                calculator.roundToDecimals(totalYearlyCost, 2),
-                true,
-            );
-        }
+        await this.adapter.setStateAsync(
+            `${basePath}.costs.paidTotal`,
+            calculator.roundToDecimals(paidTotal, 2),
+            true,
+        );
+        await this.adapter.setStateAsync(
+            `${basePath}.costs.balance`,
+            calculator.roundToDecimals(balance, 2),
+            true,
+        );
     }
 
     /**

--- a/main.js
+++ b/main.js
@@ -44,25 +44,11 @@ class UtilityMonitor extends utils.Adapter {
         this.multiMeterManager = new MultiMeterManager(this, this.consumptionManager, this.billingManager);
 
         // Initialize each utility type based on configuration
+        // Note: initializeUtility() internally calls multiMeterManager.initializeType()
         await this.initializeUtility('gas', this.config.gasAktiv);
         await this.initializeUtility('water', this.config.wasserAktiv);
         await this.initializeUtility('electricity', this.config.stromAktiv);
-
         await this.initializeUtility('pv', this.config.pvAktiv);
-
-        // Initialize Multi-Meter structures for each active type
-        if (this.config.gasAktiv) {
-            await this.multiMeterManager.initializeType('gas');
-        }
-        if (this.config.wasserAktiv) {
-            await this.multiMeterManager.initializeType('water');
-        }
-        if (this.config.stromAktiv) {
-            await this.multiMeterManager.initializeType('electricity');
-        }
-        if (this.config.pvAktiv) {
-            await this.multiMeterManager.initializeType('pv');
-        }
 
         // Initialize General Info States
         await this.setObjectNotExistsAsync('info', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,6 +229,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -237,6 +238,7 @@
       "version": "0.56.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@typescript-eslint/types": "^8.42.0",
@@ -692,6 +694,7 @@
       "version": "4.9.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -709,6 +712,7 @@
       "version": "4.12.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -717,6 +721,7 @@
       "version": "0.21.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -730,6 +735,7 @@
       "version": "0.4.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -741,6 +747,7 @@
       "version": "0.17.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -752,6 +759,7 @@
       "version": "3.3.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -774,6 +782,7 @@
       "version": "14.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -797,6 +806,7 @@
       "version": "2.1.7",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -805,6 +815,7 @@
       "version": "0.4.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -1010,6 +1021,7 @@
       "version": "0.19.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1018,6 +1030,7 @@
       "version": "0.16.7",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -1030,6 +1043,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -1042,6 +1056,7 @@
       "version": "0.4.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -1663,6 +1678,7 @@
       "version": "0.2.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
@@ -1727,7 +1743,8 @@
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1804,7 +1821,8 @@
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.17",
@@ -1826,12 +1844,14 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -1872,6 +1892,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.50.0",
@@ -1899,6 +1920,7 @@
       "version": "7.0.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -1931,6 +1953,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.50.0",
         "@typescript-eslint/types": "^8.50.0",
@@ -1951,6 +1974,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.50.0",
         "@typescript-eslint/visitor-keys": "8.50.0"
@@ -1967,6 +1991,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1982,6 +2007,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.50.0",
         "@typescript-eslint/typescript-estree": "8.50.0",
@@ -2005,6 +2031,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2017,6 +2044,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/project-service": "8.50.0",
         "@typescript-eslint/tsconfig-utils": "8.50.0",
@@ -2043,6 +2071,7 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2051,6 +2080,7 @@
       "version": "9.0.5",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2065,6 +2095,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.50.0",
@@ -2087,6 +2118,7 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.50.0",
         "eslint-visitor-keys": "^4.2.1"
@@ -2103,6 +2135,7 @@
       "version": "4.2.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2126,7 +2159,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2157,6 +2189,7 @@
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -2254,6 +2287,7 @@
       "version": "0.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2269,6 +2303,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "is-array-buffer": "^3.0.5"
@@ -2289,6 +2324,7 @@
       "version": "3.1.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -2310,6 +2346,7 @@
       "version": "1.2.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -2329,6 +2366,7 @@
       "version": "1.2.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -2349,6 +2387,7 @@
       "version": "1.3.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -2366,6 +2405,7 @@
       "version": "1.3.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -2383,6 +2423,7 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -2398,6 +2439,7 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.8",
@@ -2474,6 +2516,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2487,6 +2530,7 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -2556,6 +2600,7 @@
       "version": "2.9.10",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -2851,6 +2896,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.20"
       },
@@ -2870,6 +2916,7 @@
       "version": "1.0.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -2914,6 +2961,7 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2946,7 +2994,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -2957,7 +3006,6 @@
       "version": "4.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -3000,7 +3048,8 @@
     "node_modules/change-case": {
       "version": "5.4.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/check-error": {
       "version": "1.0.3",
@@ -3046,6 +3095,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3054,6 +3104,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -3065,6 +3116,7 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3139,6 +3191,7 @@
       "version": "1.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -3219,6 +3272,7 @@
       "version": "3.47.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browserslist": "^4.28.0"
       },
@@ -3293,6 +3347,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -3309,6 +3364,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -3325,6 +3381,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3415,6 +3472,7 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3431,6 +3489,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -3490,6 +3549,7 @@
       "version": "2.1.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -3641,7 +3701,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3796,6 +3857,7 @@
       "version": "1.24.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
         "arraybuffer.prototype.slice": "^1.0.4",
@@ -3879,6 +3941,7 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -3930,6 +3993,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -3941,6 +4005,7 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-callable": "^1.2.7",
         "is-date-object": "^1.0.5",
@@ -4179,6 +4244,7 @@
       "version": "0.3.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -4189,6 +4255,7 @@
       "version": "3.2.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -4197,6 +4264,7 @@
       "version": "2.12.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7"
       },
@@ -4213,6 +4281,7 @@
       "version": "3.2.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -4221,6 +4290,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4253,6 +4323,7 @@
       "version": "3.2.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -4261,6 +4332,7 @@
       "version": "6.3.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4323,6 +4395,7 @@
       "version": "7.37.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -4366,6 +4439,7 @@
       "version": "2.0.0-next.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -4382,6 +4456,7 @@
       "version": "6.3.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4390,6 +4465,7 @@
       "version": "60.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "@eslint-community/eslint-utils": "^4.7.0",
@@ -4424,6 +4500,7 @@
       "version": "0.15.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -4435,6 +4512,7 @@
       "version": "0.3.5",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
@@ -4447,6 +4525,7 @@
       "version": "8.4.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -4462,6 +4541,7 @@
       "version": "3.4.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -4473,6 +4553,7 @@
       "version": "4.2.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4484,6 +4565,7 @@
       "version": "6.0.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -4495,6 +4577,7 @@
       "version": "10.4.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -4511,6 +4594,7 @@
       "version": "4.2.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4534,6 +4618,7 @@
       "version": "1.6.0",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -4545,6 +4630,7 @@
       "version": "4.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -4556,6 +4642,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4713,7 +4800,8 @@
     "node_modules/fast-diff": {
       "version": "1.3.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4789,6 +4877,7 @@
       "version": "8.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -4883,6 +4972,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4902,6 +4992,7 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -4913,7 +5004,8 @@
     "node_modules/flatted": {
       "version": "3.3.3",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -4938,6 +5030,7 @@
       "version": "0.3.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -5066,6 +5159,7 @@
       "version": "1.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -5085,6 +5179,7 @@
       "version": "1.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5120,6 +5215,7 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5201,6 +5297,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -5289,6 +5386,7 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -5408,6 +5506,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5427,6 +5526,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5438,6 +5538,7 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.0"
       },
@@ -5652,6 +5753,7 @@
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5673,6 +5775,7 @@
       "version": "3.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -5688,6 +5791,7 @@
       "version": "0.1.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -5696,6 +5800,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5712,6 +5817,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.2",
@@ -5733,6 +5839,7 @@
       "version": "3.0.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -5749,6 +5856,7 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "async-function": "^1.0.0",
         "call-bound": "^1.0.3",
@@ -5767,6 +5875,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-bigints": "^1.0.2"
       },
@@ -5792,6 +5901,7 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -5807,6 +5917,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "builtin-modules": "^5.0.0"
       },
@@ -5821,6 +5932,7 @@
       "version": "1.2.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5832,6 +5944,7 @@
       "version": "2.16.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -5846,6 +5959,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "get-intrinsic": "^1.2.6",
@@ -5862,6 +5976,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -5885,6 +6000,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -5907,6 +6023,7 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.4",
         "generator-function": "^2.0.0",
@@ -5947,6 +6064,7 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5958,6 +6076,7 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5985,6 +6104,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -6024,6 +6144,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -6041,6 +6162,7 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6052,6 +6174,7 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -6077,6 +6200,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -6092,6 +6216,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-symbols": "^1.1.0",
@@ -6108,6 +6233,7 @@
       "version": "1.1.15",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -6138,6 +6264,7 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6149,6 +6276,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -6163,6 +6291,7 @@
       "version": "2.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "get-intrinsic": "^1.2.6"
@@ -6185,7 +6314,8 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6201,6 +6331,7 @@
       "version": "1.1.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-object-atoms": "^1.0.0",
@@ -6230,7 +6361,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -6252,6 +6384,7 @@
       "version": "5.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -6294,6 +6427,7 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6312,7 +6446,8 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -6327,7 +6462,8 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -6379,6 +6515,7 @@
       "version": "3.3.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -6412,6 +6549,7 @@
       "version": "4.5.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -6420,6 +6558,7 @@
       "version": "0.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -6464,7 +6603,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -6507,6 +6647,7 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6641,6 +6782,7 @@
       "version": "1.2.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6768,7 +6910,8 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -6816,7 +6959,8 @@
     "node_modules/node-releases": {
       "version": "2.0.27",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nodemon": {
       "version": "3.1.11",
@@ -6927,6 +7071,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6935,6 +7080,7 @@
       "version": "4.1.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -6954,6 +7100,7 @@
       "version": "1.1.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -6968,6 +7115,7 @@
       "version": "2.0.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6985,6 +7133,7 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6998,6 +7147,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -7059,6 +7209,7 @@
       "version": "0.9.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -7075,6 +7226,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.2.6",
         "object-keys": "^1.1.1",
@@ -7124,6 +7276,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -7135,6 +7288,7 @@
       "version": "0.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-statements": "1.0.11"
       }
@@ -7142,7 +7296,8 @@
     "node_modules/parse-statements": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5": {
       "version": "1.5.1",
@@ -7175,7 +7330,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -7241,6 +7397,7 @@
       "version": "8.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7262,6 +7419,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7270,6 +7428,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -7293,6 +7452,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-diff": "^1.1.2"
       },
@@ -7304,6 +7464,7 @@
       "version": "15.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7465,7 +7626,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -7495,6 +7657,7 @@
       "version": "1.0.10",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -7516,6 +7679,7 @@
       "version": "0.1.27",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "regexp-tree": "bin/regexp-tree"
       }
@@ -7524,6 +7688,7 @@
       "version": "1.5.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -7543,6 +7708,7 @@
       "version": "0.12.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -7554,6 +7720,7 @@
       "version": "3.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -7645,6 +7812,7 @@
       "version": "1.22.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -7664,6 +7832,7 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7758,6 +7927,7 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.2",
@@ -7795,6 +7965,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "isarray": "^2.0.5"
@@ -7810,6 +7981,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -7975,6 +8147,7 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -7991,6 +8164,7 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -8005,6 +8179,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -8126,7 +8301,6 @@
       "version": "21.0.0",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.5",
@@ -8328,12 +8502,14 @@
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "dev": true,
-      "license": "CC-BY-3.0"
+      "license": "CC-BY-3.0",
+      "peer": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -8342,7 +8518,8 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.22",
       "dev": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/split": {
       "version": "0.3.3",
@@ -8391,6 +8568,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
@@ -8474,6 +8652,7 @@
       "version": "4.0.12",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -8500,6 +8679,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -8509,6 +8689,7 @@
       "version": "1.2.10",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.2",
@@ -8529,6 +8710,7 @@
       "version": "1.0.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.2",
@@ -8546,6 +8728,7 @@
       "version": "1.0.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -8585,6 +8768,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8601,6 +8785,7 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8639,6 +8824,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8655,6 +8841,7 @@
       "version": "0.11.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.9"
       },
@@ -8755,6 +8942,7 @@
       "version": "0.2.15",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -8770,6 +8958,7 @@
       "version": "6.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -8842,6 +9031,7 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12"
       },
@@ -8853,6 +9043,7 @@
       "version": "3.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -8864,6 +9055,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -8891,6 +9083,7 @@
       "version": "0.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -8933,6 +9126,7 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -8946,6 +9140,7 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
@@ -8964,6 +9159,7 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
@@ -8984,6 +9180,7 @@
       "version": "1.0.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -9003,7 +9200,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9064,6 +9260,7 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
@@ -9121,6 +9318,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -9135,7 +9333,8 @@
     "node_modules/update-browserslist-db/node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -9221,6 +9420,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-bigint": "^1.1.0",
         "is-boolean-object": "^1.2.1",
@@ -9239,6 +9439,7 @@
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
@@ -9265,6 +9466,7 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -9282,6 +9484,7 @@
       "version": "1.1.19",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.utility-monitor",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Monitor gas, water, and electricity consumption with cost calculation",
   "author": {
     "name": "fischi87",
@@ -39,18 +39,18 @@
     "@iobroker/adapter-core": "^3.3.2"
   },
   "devDependencies": {
-    "@alcalzone/release-script": "~5.0.0",
-    "@alcalzone/release-script-plugin-iobroker": "~4.0.0",
-    "@alcalzone/release-script-plugin-license": "~4.0.0",
-    "@alcalzone/release-script-plugin-manual-review": "~4.0.0",
-    "@iobroker/adapter-dev": "~1.5.0",
-    "@iobroker/dev-server": "~0.8.0",
-    "@iobroker/eslint-config": "~2.2.0",
-    "@iobroker/testing": "~5.2.2",
-    "@tsconfig/node20": "~20.1.8",
-    "@types/iobroker": "npm:@iobroker/types@~7.1.0",
-    "@types/node": "~20.19.27",
-    "typescript": "~5.9.3"
+    "@alcalzone/release-script": "^5.0.0",
+    "@alcalzone/release-script-plugin-iobroker": "^4.0.0",
+    "@alcalzone/release-script-plugin-license": "^4.0.0",
+    "@alcalzone/release-script-plugin-manual-review": "^4.0.0",
+    "@iobroker/adapter-dev": "^1.5.0",
+    "@iobroker/dev-server": "^0.8.0",
+    "@iobroker/eslint-config": "^2.2.0",
+    "@iobroker/testing": "^5.2.2",
+    "@tsconfig/node20": "^20.1.8",
+    "@types/iobroker": "npm:@iobroker/types@^7.1.0",
+    "@types/node": "^20.19.27",
+    "typescript": "^5.9.3"
   },
   "main": "main.js",
   "files": [


### PR DESCRIPTION
## 🎯 Summary
Version 1.4.5 release with critical multi-meter cost calculation fixes.

## 🐛 Bugs Fixed
- **Main Meter Sync**: Removed duplicate initialization preventing lastSync updates
- **basicCharge Accumulation**: Now correctly calculates `grundgebuehr × months` 
- **paidTotal Accumulation**: Now correctly calculates `abschlag × months`
- **annualFee Fixed Value**: Jahresgebühr now used as fixed yearly value (e.g., 60€ stays 60€)
- **Balance Formula**: Corrected to `totalYearly - paidTotal`

## 📦 Improvements
- Updated dev-dependencies from `~` to `^` versioning
- Cleaned up changelog (removed unpublished versions)
- Resolves ioBroker Repository Checker Issue #1

## ✅ Testing
- All 88 tests passing
- TypeScript type-check clean
- ESLint clean

## 📝 Commits
- chore: Prepare version 1.4.5 for NPM release
- fix: Critical fixes for multi-meter costs and annual fee calculation
- docs: Update README changelog for version 1.4.5
