### PR TITLE
Fix config validation errors and daily/monthly reset

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -180,7 +180,7 @@
                     "hidden": "!data.gasAktiv",
                     "label": "Grundgebühr (€/Monat)",
                     "placeholder": "z.B. 15.30",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -192,7 +192,7 @@
                     "hidden": "!data.gasAktiv",
                     "label": "Jahresgebühr (z.B. Zählermiete) (€/Jahr)",
                     "placeholder": "z.B. 20.00",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -323,7 +323,7 @@
                     "label": "Monatlicher Abschlag (€)",
                     "placeholder": "z.B. 85.00",
                     "hidden": "!data.gasAktiv",
-                    "default": 0,
+                    "default": "0",
                     "sm": 12,
                     "md": 6,
                     "xs": 12,
@@ -385,7 +385,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -394,7 +394,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "8%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -403,7 +403,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "12%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -421,7 +421,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -430,7 +430,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -439,7 +439,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         }
                     ]
                 }
@@ -585,7 +585,7 @@
                     "hidden": "!data.wasserAktiv",
                     "label": "Grundgebühr (€/Monat)",
                     "placeholder": "z.B. 5.00",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -597,7 +597,7 @@
                     "hidden": "!data.wasserAktiv",
                     "label": "Jahresgebühr (z.B. Zählermiete) (€/Jahr)",
                     "placeholder": "z.B. 20.00",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -630,7 +630,7 @@
                     "label": "Monatlicher Abschlag (€)",
                     "placeholder": "z.B. 25.00",
                     "hidden": "!data.wasserAktiv",
-                    "default": 0,
+                    "default": "0",
                     "sm": 12,
                     "md": 6,
                     "xs": 12,
@@ -692,7 +692,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -701,7 +701,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "8%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -710,7 +710,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "12%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -728,7 +728,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -737,7 +737,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -746,7 +746,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         }
                     ]
                 }
@@ -890,7 +890,7 @@
                     "type": "text",
                     "hidden": "!data.stromAktiv",
                     "label": "Grundgebühr (€/Monat)",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -901,7 +901,7 @@
                     "type": "text",
                     "hidden": "!data.stromAktiv",
                     "label": "Jahresgebühr (z.B. Zählermiete) (€/Jahr)",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -1032,7 +1032,7 @@
                     "hidden": "!data.stromAktiv",
                     "sm": 12,
                     "md": 6,
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "lg": 4,
                     "xl": 3
@@ -1092,7 +1092,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -1101,7 +1101,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "8%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -1110,7 +1110,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "12%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -1128,7 +1128,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -1137,7 +1137,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         },
                         {
                             "type": "text",
@@ -1146,7 +1146,7 @@
                             "filter": false,
                             "sort": false,
                             "width": "10%",
-                            "default": 0
+                            "default": "0"
                         }
                     ]
                 }
@@ -1290,7 +1290,7 @@
                     "type": "text",
                     "hidden": "!data.pvAktiv",
                     "label": "Grundgebühr (Messstellenbetrieb) (€/Monat)",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -1301,7 +1301,7 @@
                     "type": "text",
                     "hidden": "!data.pvAktiv",
                     "label": "Jahresgebühr (€/Jahr)",
-                    "default": 0,
+                    "default": "0",
                     "xs": 12,
                     "sm": 12,
                     "md": 6,
@@ -1437,7 +1437,7 @@
                     "type": "text",
                     "label": "Tag des Monats (1-28)",
                     "hidden": "!data.notificationEnabled || !data.notificationMonthlyEnabled",
-                    "default": 1,
+                    "default": "1",
                     "sm": 12,
                     "xs": 12,
                     "md": 4,

--- a/lib/billingManager.js
+++ b/lib/billingManager.js
@@ -560,26 +560,38 @@ class BillingManager {
 
             const nowDate = new Date(now);
 
+            // Get all meters for this type (needed for all reset checks)
+            const meters = this.adapter.multiMeterManager?.getMetersForType(type) || [];
+
             // DAILY RESET: All meters reset together at midnight
-            const lastDayStart = await this.adapter.getStateAsync(`${type}.statistics.lastDayStart`);
-            if (lastDayStart?.val) {
-                const lastDay = new Date(lastDayStart.val);
-                if (nowDate.getDate() !== lastDay.getDate()) {
-                    await this.resetDailyCounters(type);
+            // Check the first meter to see if a new day has started
+            if (meters.length > 0) {
+                const firstMeter = meters[0];
+                const basePath = `${type}.${firstMeter.name}`;
+                const lastDayStart = await this.adapter.getStateAsync(`${basePath}.statistics.lastDayStart`);
+                if (lastDayStart?.val) {
+                    const lastDay = new Date(lastDayStart.val);
+                    if (nowDate.getDate() !== lastDay.getDate()) {
+                        await this.resetDailyCounters(type);
+                    }
                 }
             }
 
             // MONTHLY RESET: All meters reset together on 1st of month
-            const lastMonthStart = await this.adapter.getStateAsync(`${type}.statistics.lastMonthStart`);
-            if (lastMonthStart?.val) {
-                const lastMonth = new Date(lastMonthStart.val);
-                if (nowDate.getMonth() !== lastMonth.getMonth()) {
-                    await this.resetMonthlyCounters(type);
+            // Check the first meter to see if a new month has started
+            if (meters.length > 0) {
+                const firstMeter = meters[0];
+                const basePath = `${type}.${firstMeter.name}`;
+                const lastMonthStart = await this.adapter.getStateAsync(`${basePath}.statistics.lastMonthStart`);
+                if (lastMonthStart?.val) {
+                    const lastMonth = new Date(lastMonthStart.val);
+                    if (nowDate.getMonth() !== lastMonth.getMonth()) {
+                        await this.resetMonthlyCounters(type);
+                    }
                 }
             }
 
             // YEARLY RESET: Each meter resets individually based on ITS contract date
-            const meters = this.adapter.multiMeterManager?.getMetersForType(type) || [];
             for (const meter of meters) {
                 const basePath = `${type}.${meter.name}`;
                 const lastYearStartState = await this.adapter.getStateAsync(`${basePath}.statistics.lastYearStart`);


### PR DESCRIPTION
- Fix type mismatch in jsonConfig.json: Change numeric defaults (0, 1) to strings ("0", "1") for all text fields This resolves the "alle Werte müssen vom Typ string sein" error when users enter values in config Affected fields: grundgebuehr, jahresgebuehr, abschlag, preis, offset, initialReading for all utility types (30 occurrences)

- Fix daily/monthly reset not triggering after v1.4.6 breaking change The reset check was trying to read non-existent global states (gas.statistics.lastDayStart) Changed to check the first meter's state (gas.main.statistics.lastDayStart) which exists Yearly reset was already correct and continues to work as expected